### PR TITLE
internal: fix lineNo handling

### DIFF
--- a/internal/testcase.go
+++ b/internal/testcase.go
@@ -289,7 +289,7 @@ func getTestCasesInFile(
 				}
 				tc.Matches = append(tc.Matches, LineMatcher{
 					Regexp: r,
-					Source: lines[lineNo],
+					Source: lines[lineNo-1],
 				})
 			} else if m := natchRx.FindStringSubmatch(l); m != nil {
 				if tc, _ = lookupTbl.Get(m[1]); tc == nil {
@@ -306,7 +306,7 @@ func getTestCasesInFile(
 				}
 				tc.Natches = append(tc.Natches, LineMatcher{
 					Regexp: r,
-					Source: lines[lineNo],
+					Source: lines[lineNo-1],
 				})
 			}
 		}


### PR DESCRIPTION
The `lineNo` variable holds the number of a line which _starts from 1_, hence to get the source code at that line, we need to subtract 1.